### PR TITLE
Use apriltags2 for tag detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(camera_positioner)
 
 find_package(catkin REQUIRED COMPONENTS
-  apriltags_ros
+  apriltags2_ros
   roscpp
   tf
 )

--- a/package.xml
+++ b/package.xml
@@ -11,11 +11,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>apriltags_ros</build_depend>
+  <build_depend>apriltags2_ros</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
 
-  <run_depend>apriltags_ros</run_depend>
+  <run_depend>apriltags2_ros</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
 </package>

--- a/src/camera_positioner.cpp
+++ b/src/camera_positioner.cpp
@@ -18,6 +18,7 @@ private:
    // latest measured position of the camera
    tf::Transform world_camera_transform;
    ros::Time latest_detection_time;
+   tf::Transform last_tag_transform;
 
    // for successful initialization the apriltag has to be detected _once_
    bool initialized;
@@ -65,11 +66,14 @@ public:
         if(msg.detections[i].id[0] == 0){
            tf::Transform tag_transform;
            tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);
-           world_camera_transform= world_tag_transform * tag_transform.inverse() * optical_transform;
            if(!initialized){
               ROS_INFO("camera positioner is running");
               initialized = true;
+           } else {
+              interpolateTransforms(last_tag_transform, tag_transform, 0.05, tag_transform);
            }
+           last_tag_transform = tag_transform;
+           world_camera_transform= world_tag_transform * tag_transform.inverse() * optical_transform;
            latest_detection_time = msg.detections[0].pose.header.stamp;
         }
       }
@@ -82,6 +86,11 @@ public:
       if(initialized){
          br.sendTransform(tf::StampedTransform(world_camera_transform, ros::Time::now(), "/world", camera_link));
       }
+   }
+
+   void interpolateTransforms(const tf::Transform& t1, const tf::Transform& t2, double fraction, tf::Transform& t_out){
+      t_out.setOrigin( t1.getOrigin()*(1-fraction) + t2.getOrigin()*fraction );
+      t_out.setRotation( t1.getRotation().slerp(t2.getRotation(), fraction) );
    }
 };
 

--- a/src/camera_positioner.cpp
+++ b/src/camera_positioner.cpp
@@ -63,7 +63,7 @@ public:
    void callback(const apriltags2_ros::AprilTagDetectionArray& msg){
       // if we got a valid tag detection, update world_camera_transform
       for (int i=0; i< msg.detections.size(); i++) {
-        if(msg.detections[i].id[0] == 0){
+        if(msg.detections[i].id.size() > 0 && msg.detections[i].id[0] == 0){
            tf::Transform tag_transform;
            tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);
            if(!initialized){

--- a/src/camera_positioner.cpp
+++ b/src/camera_positioner.cpp
@@ -1,7 +1,7 @@
 #include <ros/ros.h>
 #include <tf/transform_listener.h>
 #include <tf/transform_broadcaster.h>
-#include <apriltags_ros/AprilTagDetectionArray.h>
+#include <apriltags2_ros/AprilTagDetectionArray.h>
 
 class CameraPositioner {
 private:
@@ -59,12 +59,12 @@ public:
       }
    }
 
-   void callback(const apriltags_ros::AprilTagDetectionArray& msg){
+   void callback(const apriltags2_ros::AprilTagDetectionArray& msg){
       // if we got a valid tag detection, update world_camera_transform
       for (int i=0; i< msg.detections.size(); i++) {
-        if(msg.detections[i].id == 0){
+        if(msg.detections[i].id[0] == 0){
            tf::Transform tag_transform;
-           tf::poseMsgToTF(msg.detections[i].pose.pose, tag_transform);
+           tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);
            world_camera_transform= world_tag_transform * tag_transform.inverse() * optical_transform;
            if(!initialized){
               ROS_INFO("camera positioner is running");

--- a/src/camera_positioner_table.cpp
+++ b/src/camera_positioner_table.cpp
@@ -130,7 +130,7 @@ public:
       int get_tabletag=false;
       for (int i=0; i< msg.detections.size(); i++)
       {
-        if(msg.detections[i].id[0] == wall_tag_id_){
+        if(msg.detections[i].id[0] == wall_tag_id_)
 	{
           tf::Transform tag_transform;
           tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);

--- a/src/camera_positioner_table.cpp
+++ b/src/camera_positioner_table.cpp
@@ -153,7 +153,7 @@ public:
 	{
           get_tabletag=true;
           tabletag_size=msg.detections[i].size[0];
-         tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tabletag_transform);
+          tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tabletag_transform);
         }
      }
 

--- a/src/camera_positioner_table.cpp
+++ b/src/camera_positioner_table.cpp
@@ -1,7 +1,7 @@
 #include <ros/ros.h>
 #include <tf/transform_listener.h>
 #include <tf/transform_broadcaster.h>
-#include <apriltags_ros/AprilTagDetectionArray.h>
+#include <apriltags2_ros/AprilTagDetectionArray.h>
 
 #include <sensor_msgs/JointState.h>
 
@@ -123,17 +123,17 @@ public:
       }
    }
 
-   void callback(const apriltags_ros::AprilTagDetectionArray& msg){
+   void callback(const apriltags2_ros::AprilTagDetectionArray& msg){
       ros::NodeHandle nh("~");
       //check whether tag0 is detected, update world_camera_transform
       bool get_tag0=false;
       int get_tabletag=false;
       for (int i=0; i< msg.detections.size(); i++)
       {
-        if(msg.detections[i].id == wall_tag_id_)
+        if(msg.detections[i].id[0] == wall_tag_id_){
 	{
           tf::Transform tag_transform;
-          tf::poseMsgToTF(msg.detections[i].pose.pose, tag_transform);
+          tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);
           if(!initialized)
           {
              ROS_INFO("camera positioner is running");
@@ -149,11 +149,11 @@ public:
           latest_detection_time = msg.detections[0].pose.header.stamp;
           get_tag0=true;
         }
-        if(msg.detections[i].id == table_tag_id_)
+        if(msg.detections[i].id[0] == table_tag_id_)
 	{
           get_tabletag=true;
-          tabletag_size=msg.detections[i].size;
-         tf::poseMsgToTF(msg.detections[i].pose.pose, tabletag_transform);
+          tabletag_size=msg.detections[i].size[0];
+         tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tabletag_transform);
         }
      }
 

--- a/src/camera_positioner_table.cpp
+++ b/src/camera_positioner_table.cpp
@@ -130,32 +130,34 @@ public:
       int get_tabletag=false;
       for (int i=0; i< msg.detections.size(); i++)
       {
-        if(msg.detections[i].id[0] == wall_tag_id_)
-	{
-          tf::Transform tag_transform;
-          tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);
-          if(!initialized)
-          {
-             ROS_INFO("camera positioner is running");
-             initialized = true;
-             world_camera_transform= world_tag_transform * tag_transform.inverse() * optical_transform;
-          }
-          else
-	  {
-             tf::Transform world_camera_transform_new;
-             interpolateTransforms(world_camera_transform, world_tag_transform * tag_transform.inverse() * optical_transform, filter_weight, world_camera_transform_new);
-             world_camera_transform= world_camera_transform_new;
-          }
-          latest_detection_time = msg.detections[0].pose.header.stamp;
-          get_tag0=true;
-        }
-        if(msg.detections[i].id[0] == table_tag_id_)
-	{
-          get_tabletag=true;
-          tabletag_size=msg.detections[i].size[0];
-          tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tabletag_transform);
-        }
-     }
+         if(msg.detections[i].id.size() > 0) {
+            if(msg.detections[i].id[0] == wall_tag_id_)
+            {
+               tf::Transform tag_transform;
+               tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);
+               if(!initialized)
+               {
+                  ROS_INFO("camera positioner is running");
+                  initialized = true;
+                  world_camera_transform= world_tag_transform * tag_transform.inverse() * optical_transform;
+               }
+               else
+               {
+                  tf::Transform world_camera_transform_new;
+                  interpolateTransforms(world_camera_transform, world_tag_transform * tag_transform.inverse() * optical_transform, filter_weight, world_camera_transform_new);
+                  world_camera_transform= world_camera_transform_new;
+               }
+               latest_detection_time = msg.detections[0].pose.header.stamp;
+               get_tag0=true;
+            }
+            if(msg.detections[i].id[0] == table_tag_id_ && msg.detections[i].size.size() > 0)
+            {
+               get_tabletag=true;
+               tabletag_size=msg.detections[i].size[0];
+               tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tabletag_transform);
+            }
+         }
+      }
 
       // get tabletag position based on tag0 at the beginning
       // if get_tag0, update world_camera_transform and world_tabletag_transform based on tag0


### PR DESCRIPTION
This PR is necessary when using apriltags2 as introduced [here](https://github.com/TAMS-Group/tams_ur5_setup/pull/7). 

The new message type allows multiple poses in a single detection ( bundle detection ). When using single april tag detections as in our configuration, we need to simply choose the first and only pose available in the detection message.
