### PR TITLE
Use Apriltags2 + UR5 mount bundle detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(camera_positioner)
+add_compile_options(-std=c++11)
+
 
 find_package(catkin REQUIRED COMPONENTS
   apriltags2_ros

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(camera_positioner)
 
 find_package(catkin REQUIRED COMPONENTS
-  apriltags_ros
+  apriltags2_ros
   roscpp
   tf
 )

--- a/package.xml
+++ b/package.xml
@@ -11,11 +11,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>apriltags_ros</build_depend>
+  <build_depend>apriltags2_ros</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
 
-  <run_depend>apriltags_ros</run_depend>
+  <run_depend>apriltags2_ros</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
 </package>

--- a/src/camera_positioner.cpp
+++ b/src/camera_positioner.cpp
@@ -20,6 +20,9 @@ private:
    ros::Time latest_detection_time;
    tf::Transform last_tag_transform;
 
+   // Fraction used for transform interpolation
+   float filter_weight;
+
    // for successful initialization the apriltag has to be detected _once_
    bool initialized;
 
@@ -32,6 +35,7 @@ public:
    {
       ros::NodeHandle node;
       ros::NodeHandle private_node("~");
+      private_node.param<float>("transform_filter_weight", filter_weight, 0.05);
       private_node.param<std::string>("camera_rgb_optical_frame", camera_rgb_optical_frame, "/camera_rgb_optical_frame");
       private_node.param<std::string>("camera_link", camera_link, "/camera_link");
       getConstantTransforms();
@@ -70,7 +74,7 @@ public:
               ROS_INFO("camera positioner is running");
               initialized = true;
            } else {
-              interpolateTransforms(last_tag_transform, tag_transform, 0.05, tag_transform);
+              interpolateTransforms(last_tag_transform, tag_transform, filter_weight, tag_transform);
            }
            last_tag_transform = tag_transform;
            world_camera_transform= world_tag_transform * tag_transform.inverse() * optical_transform;

--- a/src/camera_positioner.cpp
+++ b/src/camera_positioner.cpp
@@ -39,7 +39,7 @@ public:
    {
       ros::NodeHandle node;
       ros::NodeHandle private_node("~");
-      private_node.param<float>("transform_filter_weight", filter_weight, 0.05);
+      private_node.param<float>("transform_filter_weight", filter_weight, 0.25);
       private_node.getParam("bundle_tags", bundle_tags);
       private_node.param<std::string>("camera_rgb_optical_frame", camera_rgb_optical_frame, "/camera_rgb_optical_frame");
       private_node.param<std::string>("camera_link", camera_link, "/camera_link");

--- a/src/camera_positioner.cpp
+++ b/src/camera_positioner.cpp
@@ -18,6 +18,7 @@ private:
    // latest measured position of the camera
    tf::Transform world_camera_transform;
    ros::Time latest_detection_time;
+   tf::Transform last_tag_transform;
 
    // for successful initialization the apriltag has to be detected _once_
    bool initialized;
@@ -65,11 +66,14 @@ public:
         if(msg.detections[i].id[0] == 0){
            tf::Transform tag_transform;
            tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);
-           world_camera_transform= world_tag_transform * tag_transform.inverse() * optical_transform;
            if(!initialized){
               ROS_INFO("camera positioner is running");
               initialized = true;
+           } else {
+              interpolateTransforms(last_tag_transform, tag_transform, 0.05, tag_transform);
            }
+           last_tag_transform = tag_transform;
+           world_camera_transform= world_tag_transform * tag_transform.inverse() * optical_transform;
            latest_detection_time = msg.detections[0].pose.header.stamp;
         }
       }
@@ -82,6 +86,11 @@ public:
       if(initialized){
          br.sendTransform(tf::StampedTransform(world_camera_transform, ros::Time::now(), "/world", camera_link));
       }
+   }
+
+   void interpolateTransforms(const tf::Transform& t1, const tf::Transform& t2, double fraction, tf::Transform& t_out){
+      t_out.setOrigin( t1.getOrigin()*(1-fraction) + t2.getOrigin()*fraction );
+      t_out.setRotation( t1.getRotation().slerp(t2.getRotation(), fraction) );
    }
 };
 

--- a/src/camera_positioner.cpp
+++ b/src/camera_positioner.cpp
@@ -63,7 +63,7 @@ public:
    void callback(const apriltags2_ros::AprilTagDetectionArray& msg){
       // if we got a valid tag detection, update world_camera_transform
       for (int i=0; i< msg.detections.size(); i++) {
-        if(msg.detections[i].id[0] == 0){
+        if(msg.detections[i].id.size() > 0 && msg.detections[i].id[0] == 0){
            tf::Transform tag_transform;
            tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);
            if(!initialized){

--- a/src/camera_positioner.cpp
+++ b/src/camera_positioner.cpp
@@ -1,7 +1,7 @@
 #include <ros/ros.h>
 #include <tf/transform_listener.h>
 #include <tf/transform_broadcaster.h>
-#include <apriltags_ros/AprilTagDetectionArray.h>
+#include <apriltags2_ros/AprilTagDetectionArray.h>
 
 class CameraPositioner {
 private:
@@ -59,12 +59,12 @@ public:
       }
    }
 
-   void callback(const apriltags_ros::AprilTagDetectionArray& msg){
+   void callback(const apriltags2_ros::AprilTagDetectionArray& msg){
       // if we got a valid tag detection, update world_camera_transform
       for (int i=0; i< msg.detections.size(); i++) {
-        if(msg.detections[i].id == 0){
+        if(msg.detections[i].id[0] == 0){
            tf::Transform tag_transform;
-           tf::poseMsgToTF(msg.detections[i].pose.pose, tag_transform);
+           tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);
            world_camera_transform= world_tag_transform * tag_transform.inverse() * optical_transform;
            if(!initialized){
               ROS_INFO("camera positioner is running");

--- a/src/camera_positioner.cpp
+++ b/src/camera_positioner.cpp
@@ -40,7 +40,10 @@ public:
       ros::NodeHandle node;
       ros::NodeHandle private_node("~");
       private_node.param<float>("transform_filter_weight", filter_weight, 0.25);
-      private_node.getParam("bundle_tags", bundle_tags);
+      if(!private_node.getParam("bundle_tags", bundle_tags) || bundle_tags.size() == 0) {
+	ROS_ERROR("CameraPositioner was launched without any defined apriltag bundle ids! Please check your launch file for the rosparam bundle_tags.");
+	return;
+      }
       private_node.param<std::string>("camera_rgb_optical_frame", camera_rgb_optical_frame, "/camera_rgb_optical_frame");
       private_node.param<std::string>("camera_link", camera_link, "/camera_link");
       getConstantTransforms();

--- a/src/camera_positioner_table.cpp
+++ b/src/camera_positioner_table.cpp
@@ -37,7 +37,6 @@ private:
    // for successful initialization the apriltag has to be detected _once_
    bool initialized;
    int get_tabletag_transform;
-   float tabletag_size;
 
    double filter_weight;
 
@@ -150,10 +149,9 @@ public:
                latest_detection_time = msg.detections[0].pose.header.stamp;
                get_tag0=true;
             }
-            if(msg.detections[i].id[0] == table_tag_id_ && msg.detections[i].size.size() > 0)
+            if(msg.detections[i].id[0] == table_tag_id_)
             {
                get_tabletag=true;
-               tabletag_size=msg.detections[i].size[0];
                tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tabletag_transform);
             }
          } else {

--- a/src/camera_positioner_table.cpp
+++ b/src/camera_positioner_table.cpp
@@ -130,7 +130,7 @@ public:
       int get_tabletag=false;
       for (int i=0; i< msg.detections.size(); i++)
       {
-        if(msg.detections[i].id[0] == wall_tag_id_){
+        if(msg.detections[i].id[0] == wall_tag_id_)
 	{
           tf::Transform tag_transform;
           tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);

--- a/src/camera_positioner_table.cpp
+++ b/src/camera_positioner_table.cpp
@@ -153,7 +153,7 @@ public:
 	{
           get_tabletag=true;
           tabletag_size=msg.detections[i].size[0];
-         tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tabletag_transform);
+          tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tabletag_transform);
         }
      }
 

--- a/src/camera_positioner_table.cpp
+++ b/src/camera_positioner_table.cpp
@@ -1,7 +1,7 @@
 #include <ros/ros.h>
 #include <tf/transform_listener.h>
 #include <tf/transform_broadcaster.h>
-#include <apriltags_ros/AprilTagDetectionArray.h>
+#include <apriltags2_ros/AprilTagDetectionArray.h>
 
 #include <sensor_msgs/JointState.h>
 
@@ -123,17 +123,17 @@ public:
       }
    }
 
-   void callback(const apriltags_ros::AprilTagDetectionArray& msg){
+   void callback(const apriltags2_ros::AprilTagDetectionArray& msg){
       ros::NodeHandle nh("~");
       //check whether tag0 is detected, update world_camera_transform
       bool get_tag0=false;
       int get_tabletag=false;
       for (int i=0; i< msg.detections.size(); i++)
       {
-        if(msg.detections[i].id == wall_tag_id_)
+        if(msg.detections[i].id[0] == wall_tag_id_){
 	{
           tf::Transform tag_transform;
-          tf::poseMsgToTF(msg.detections[i].pose.pose, tag_transform);
+          tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);
           if(!initialized)
           {
              ROS_INFO("camera positioner is running");
@@ -149,11 +149,11 @@ public:
           latest_detection_time = msg.detections[0].pose.header.stamp;
           get_tag0=true;
         }
-        if(msg.detections[i].id == table_tag_id_)
+        if(msg.detections[i].id[0] == table_tag_id_)
 	{
           get_tabletag=true;
-          tabletag_size=msg.detections[i].size;
-         tf::poseMsgToTF(msg.detections[i].pose.pose, tabletag_transform);
+          tabletag_size=msg.detections[i].size[0];
+         tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tabletag_transform);
         }
      }
 

--- a/src/camera_positioner_table.cpp
+++ b/src/camera_positioner_table.cpp
@@ -130,32 +130,34 @@ public:
       int get_tabletag=false;
       for (int i=0; i< msg.detections.size(); i++)
       {
-        if(msg.detections[i].id[0] == wall_tag_id_)
-	{
-          tf::Transform tag_transform;
-          tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);
-          if(!initialized)
-          {
-             ROS_INFO("camera positioner is running");
-             initialized = true;
-             world_camera_transform= world_tag_transform * tag_transform.inverse() * optical_transform;
-          }
-          else
-	  {
-             tf::Transform world_camera_transform_new;
-             interpolateTransforms(world_camera_transform, world_tag_transform * tag_transform.inverse() * optical_transform, filter_weight, world_camera_transform_new);
-             world_camera_transform= world_camera_transform_new;
-          }
-          latest_detection_time = msg.detections[0].pose.header.stamp;
-          get_tag0=true;
-        }
-        if(msg.detections[i].id[0] == table_tag_id_)
-	{
-          get_tabletag=true;
-          tabletag_size=msg.detections[i].size[0];
-          tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tabletag_transform);
-        }
-     }
+         if(msg.detections[i].id.size() > 0) {
+            if(msg.detections[i].id[0] == wall_tag_id_)
+            {
+               tf::Transform tag_transform;
+               tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tag_transform);
+               if(!initialized)
+               {
+                  ROS_INFO("camera positioner is running");
+                  initialized = true;
+                  world_camera_transform= world_tag_transform * tag_transform.inverse() * optical_transform;
+               }
+               else
+               {
+                  tf::Transform world_camera_transform_new;
+                  interpolateTransforms(world_camera_transform, world_tag_transform * tag_transform.inverse() * optical_transform, filter_weight, world_camera_transform_new);
+                  world_camera_transform= world_camera_transform_new;
+               }
+               latest_detection_time = msg.detections[0].pose.header.stamp;
+               get_tag0=true;
+            }
+            if(msg.detections[i].id[0] == table_tag_id_ && msg.detections[i].size.size() > 0)
+            {
+               get_tabletag=true;
+               tabletag_size=msg.detections[i].size[0];
+               tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tabletag_transform);
+            }
+         }
+      }
 
       // get tabletag position based on tag0 at the beginning
       // if get_tag0, update world_camera_transform and world_tabletag_transform based on tag0

--- a/src/camera_positioner_table.cpp
+++ b/src/camera_positioner_table.cpp
@@ -156,6 +156,8 @@ public:
                tabletag_size=msg.detections[i].size[0];
                tf::poseMsgToTF(msg.detections[i].pose.pose.pose, tabletag_transform);
             }
+         } else {
+           ROS_WARN_THROTTLE(5, "Found empty AprilTagDetection message!");
          }
       }
 


### PR DESCRIPTION
This PR includes https://github.com/TAMS-Group/camera_positioner/pull/5 and https://github.com/TAMS-Group/camera_positioner/pull/4 which implements apriltags2 support. Additionally the camera is now localized by an apriltag bundle instead of the single wall tag to improve accuracy and robustness.
This PR is co-dependent on the equally named [PR](https://github.com/TAMS-Group/tams_ur5_setup/pull/8) adressing [tams_ur5_setup](https://github.com/TAMS-Group/tams_ur5_setup).