### PR TITLE
Check frame_id in detections message

### DIFF
--- a/src/camera_positioner.cpp
+++ b/src/camera_positioner.cpp
@@ -81,6 +81,8 @@ public:
      for (int i=0; i< msg.detections.size(); i++) {
        if(msg.detections[i].id.size() > 0) {
          if (std::find(bundle_tags.begin(), bundle_tags.end(), msg.detections[i].id[0]) != bundle_tags.end()) {
+           if (msg.detections[i].pose.header.frame_id != camera_link)
+             continue;
            tf::Transform bundle_transform;
            tf::poseMsgToTF(msg.detections[i].pose.pose.pose, bundle_transform);
            if(!initialized){


### PR DESCRIPTION
To allow multiple camera positioner nodes for more than one camera, we need to check the frame_id in the tag_detections message. Otherwise the cameras disturb each others transform.

@v4hn, @HitLyn @lianghongzhuo do you know which frame_id is set in the tag_detections message for the kinect2, is it the camera_link or the camera_rgb_optical_frame? There is no such differentiation for the usb_cam.